### PR TITLE
Priority: Critical: Token boundary bypass in classes/storage.php

### DIFF
--- a/classes/storage.php
+++ b/classes/storage.php
@@ -79,7 +79,15 @@ class storage implements
     public function getAccessToken($oauthtoken) {
         global $CFG;
         require_once($CFG->dirroot . '/webservice/lib.php');
-        $token = $this->db->get_record('external_tokens', ['token' => $oauthtoken, 'tokentype' => EXTERNAL_TOKEN_PERMANENT]);
+        $extservice = $this->db->get_record('external_services', ['shortname' => 'learnwise'], 'id');
+        $token = false;
+        if ($extservice) {
+            $token = $this->db->get_record('external_tokens', [
+                'token' => $oauthtoken,
+                'tokentype' => EXTERNAL_TOKEN_PERMANENT,
+                'externalserviceid' => $extservice->id,
+            ]);
+        }
         if ($token) {
             $client = util::get_or_generate_client();
             webservice::update_token_lastaccess($token);


### PR DESCRIPTION
## Summary
- Restrict accepted permanent tokens to the LearnWise external service in OAuth access token lookup.
- Isolated fix branch for one audited issue.

## Test plan
- [ ] Run Moodle plugin checks (phpcs/phpunit) in CI
- [ ] Verify affected endpoint/flow manually
- [ ] Confirm no regressions in related flows

Made with [Cursor](https://cursor.com)