### PR TITLE
Priority: High: OAuth state protection disabled in classes/server.php

### DIFF
--- a/classes/server.php
+++ b/classes/server.php
@@ -44,7 +44,7 @@ class server extends OAuth2Server {
         if (is_null(self::$instance)) {
             $storage = new storage();
             $server = new server($storage, [
-                'enforce_state' => false,
+                'enforce_state' => true,
                 'access_lifetime' => HOURSECS,
                 'refresh_token_lifetime' => WEEKSECS,
             ]);


### PR DESCRIPTION
## Summary
- Enable OAuth state enforcement in server configuration.
- Isolated fix branch for one audited issue.

## Test plan
- [ ] Run Moodle plugin checks (phpcs/phpunit) in CI
- [ ] Verify affected endpoint/flow manually
- [ ] Confirm no regressions in related flows

Made with [Cursor](https://cursor.com)