### PR TITLE
Priority: High: Missing explicit grading capability check in classes/external/assign/grade.php

### DIFF
--- a/classes/external/assign/grade.php
+++ b/classes/external/assign/grade.php
@@ -101,6 +101,7 @@ class grade extends baseapi {
 
         $cm = $DB->get_record('course_modules', ['id' => $params['assignment_id']], '*', MUST_EXIST);
         [$assignment, $course, $cm, $context] = self::validate_assignment($cm->instance);
+        require_capability('mod/assign:grade', $context);
 
         $grade = $assignment->get_user_grade($params['user_id'], true);
         $originalgrade = $grade->grade;


### PR DESCRIPTION
## Summary
- Require mod/assign:grade capability before grading operations.
- Isolated fix branch for one audited issue.

## Test plan
- [ ] Run Moodle plugin checks (phpcs/phpunit) in CI
- [ ] Verify affected endpoint/flow manually
- [ ] Confirm no regressions in related flows

Made with [Cursor](https://cursor.com)