### PR TITLE
Priority: Medium: Route type misclassified in api/callbacks.php

### DIFF
--- a/api/callbacks.php
+++ b/api/callbacks.php
@@ -112,7 +112,7 @@ $callbacks = [
 foreach ($callbacks as $classname => $info) {
     $info['component'] = 'local_learnwise';
     $info['loginrequired'] = true;
-    $info['type'] = 'read';
+    $info['type'] = $classname === grade::class ? 'write' : 'read';
     $info['methodname'] = 'execute';
     $info['classname'] = $classname;
     $callbacks[$classname] = $info;


### PR DESCRIPTION
## Summary
- Mark grading callback route type as write instead of read.
- Isolated fix branch for one audited issue.

## Test plan
- [ ] Run Moodle plugin checks (phpcs/phpunit) in CI
- [ ] Verify affected endpoint/flow manually
- [ ] Confirm no regressions in related flows

Made with [Cursor](https://cursor.com)