### PR TITLE
Priority: Low: Typo in environment form value in classes/output/setup.php

### DIFF
--- a/classes/output/setup.php
+++ b/classes/output/setup.php
@@ -62,7 +62,7 @@ class setup implements renderable, templatable {
         $this->formvalues->ltiStatus = !empty($config->ltisetup);
         $this->formvalues->webServicesStatus = !empty($config->webservices);
         $this->formvalues->liveApiStatus = !empty($config->liveapi);
-        $this->formvalues->evironment = $env;
+        $this->formvalues->environment = $env;
         $this->formvalues->region = !empty($config->region) ? $config->region : constants::REGION;
         $this->formvalues->ltiAssistantId = !empty($config->ltiassistantid) ? $config->ltiassistantid : '';
         $this->formvalues->aiAssessmentStatus = !empty($config->aiassessment);


### PR DESCRIPTION
## Summary
- Fix typo in setup form environment state key.
- Isolated fix branch for one audited issue.

## Test plan
- [ ] Run Moodle plugin checks (phpcs/phpunit) in CI
- [ ] Verify affected endpoint/flow manually
- [ ] Confirm no regressions in related flows

Made with [Cursor](https://cursor.com)