### PR TITLE
Priority: Low: Message type mismatch in classes/external/forum/discussions.php

### DIFF
--- a/classes/external/forum/discussions.php
+++ b/classes/external/forum/discussions.php
@@ -151,7 +151,7 @@ class discussions extends baseapi {
         $structure = new external_single_structure([
             'id' => new external_value(PARAM_INT, 'discussion post id'),
             'subject' => new external_value(PARAM_TEXT, 'post subject'),
-            'message' => new external_value(PARAM_RAW, 'post message'),
+            'message' => new external_value(PARAM_TEXT, 'post message'),
             'parentid' => new external_value(PARAM_INT, 'post parent id'),
             'timecreated' => new external_value(PARAM_INT, 'posted time in unix format'),
         ]);


### PR DESCRIPTION
## Summary
- Align forum message output type with stripped text content.
- Isolated fix branch for one audited issue.

## Test plan
- [ ] Run Moodle plugin checks (phpcs/phpunit) in CI
- [ ] Verify affected endpoint/flow manually
- [ ] Confirm no regressions in related flows

Made with [Cursor](https://cursor.com)