### PR TITLE
version bump

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component    = 'local_learnwise';
-$plugin->release      = '1.3.2a';
-$plugin->version      = 2026041000;
+$plugin->release      = '1.3.3a';
+$plugin->version      = 2026041001;
 $plugin->requires     = 2020061500;
 $plugin->supported    = [39, 501];
 $plugin->maturity     = MATURITY_STABLE;


### PR DESCRIPTION
Bump local_learnwise release metadata to 1.3.3a with an incremented plugin version for upgrade detection.

Made-with: Cursor