### PR TITLE
[INNO-828] Remove implicit Moodle API pagination

### DIFF
--- a/classes/api_response.php
+++ b/classes/api_response.php
@@ -32,6 +32,44 @@ class api_response extends oauth2_response {
     private $emptyarrayresponse = false;
 
     /**
+     * @var int|null Maximum encoded JSON response size in bytes.
+     */
+    private $maxresponsebytes = null;
+
+    /**
+     * @var string|null Error description used when the response exceeds its size limit.
+     */
+    private $responseoversizedescription = null;
+
+    /**
+     * Reject JSON responses larger than the configured byte limit.
+     *
+     * @param int $maxresponsebytes Maximum encoded JSON response size in bytes
+     * @param string $errordescription Error description returned to the client
+     * @return void
+     */
+    public function set_response_size_limit(int $maxresponsebytes, string $errordescription) {
+        $this->maxresponsebytes = $maxresponsebytes;
+        $this->responseoversizedescription = $errordescription;
+    }
+
+    #[\Override]
+    public function setParameters(array $parameters) {
+        $encoded = json_encode($parameters);
+        if (
+            $this->maxresponsebytes !== null
+            && $encoded !== false
+            && strlen($encoded) > $this->maxresponsebytes
+        ) {
+            parent::setParameters([]);
+            parent::setError(413, 'response_too_large', $this->responseoversizedescription);
+            return;
+        }
+
+        parent::setParameters($parameters);
+    }
+
+    /**
      * Preserve list response shape when Moodle returns an empty external_multiple_structure.
      *
      * @param bool $emptyarrayresponse Whether empty parameters should encode as []

--- a/classes/external/ws_proxy.php
+++ b/classes/external/ws_proxy.php
@@ -18,9 +18,7 @@ namespace local_learnwise\external;
 
 use core_component;
 use core_plugin_manager;
-use local_learnwise\api_response;
 use local_learnwise\api_server;
-use local_learnwise\util;
 
 /**
  * Generic WS proxy - translates REST-style JSON requests into Moodle WS function calls.
@@ -35,11 +33,11 @@ use local_learnwise\util;
  */
 class ws_proxy {
     /**
-     * Indicates function is called and used when formatting response
+     * Maximum JSON response size sent through the WS proxy.
      *
-     * @var bool
+     * @var int
      */
-    protected static $called = false;
+    protected const MAX_RESPONSE_BYTES = 10 * 1024 * 1024;
 
     /**
      * Dispatch a WS function call from URL segments and return the result.
@@ -48,7 +46,6 @@ class ws_proxy {
      * @return void
      */
     public static function dispatch(api_server $apiserver) {
-        self::$called = true;
         $urlparts = $apiserver->get_urlparts();
         $response = $apiserver->get_response();
         // Reconstruct function name: /ws/mod_assign/get_assignments -> mod_assign_get_assignments.
@@ -100,7 +97,7 @@ class ws_proxy {
         $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
         if ($method === 'GET') {
             $params = $_GET;
-            // Remove internal pagination params before passing to Moodle.
+            // Ignore legacy proxy pagination controls instead of forwarding invalid parameters to Moodle.
             unset($params['_page'], $params['_per_page']);
         } else {
             $rawbody = file_get_contents('php://input');
@@ -113,40 +110,12 @@ class ws_proxy {
 
         $apiserver->set_parameters($params);
         $apiserver->set_functionname($functionname);
-        $apiserver->add_responseformatter(function ($returns) use ($response) {
-            return self::apply_pagination($returns, $response);
-        });
-    }
-
-    /**
-     * Apply proxy-level pagination to array responses.
-     *
-     * Accepts _page and _per_page query params. For array responses, slices the result
-     * and adds X-Total-Count and X-Has-More headers.
-     *
-     * @param mixed $data The function result
-     * @param api_response $response Response object (for headers)
-     * @return mixed Paginated data (or original if not an array)
-     */
-    protected static function apply_pagination($data, $response) {
-        // Only paginate indexed arrays (lists).
-        if (!self::$called || !is_array($data) || empty($data) || !util::array_is_list($data)) {
-            return $data;
-        }
-
-        $page = max(1, optional_param('_page', 1, PARAM_INT));
-        $perpage = max(1, min(200, optional_param('_per_page', 50, PARAM_INT)));
-        $total = count($data);
-        $offset = ($page - 1) * $perpage;
-
-        $response->addHttpHeaders([
-            'X-Total-Count' => (string)$total,
-            'X-Has-More' => ($offset + $perpage < $total) ? 'true' : 'false',
-            'X-Page' => (string)$page,
-            'X-Per-Page' => (string)$perpage,
-        ]);
-
-        return array_slice($data, $offset, $perpage);
+        $response->set_response_size_limit(
+            self::MAX_RESPONSE_BYTES,
+            'The Moodle API returned more than 10 MiB of JSON, so the result was not sent. '
+                . 'Retry the same endpoint with narrower filters or pagination parameters supported by that '
+                . 'Moodle endpoint.'
+        );
     }
 
     /**

--- a/tests/api_response_test.php
+++ b/tests/api_response_test.php
@@ -1,0 +1,58 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_learnwise;
+
+/**
+ * Tests for the plugin API response.
+ *
+ * @covers     \local_learnwise\api_response
+ * @package    local_learnwise
+ * @copyright  2026 LearnWise <help@learnwise.ai>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class api_response_test extends \advanced_testcase {
+    /**
+     * Responses at the configured byte limit remain unchanged.
+     */
+    public function test_response_at_size_limit_is_preserved(): void {
+        $response = new api_response();
+        $parameters = ['a' => 1];
+        $response->set_response_size_limit(7, 'Too large');
+
+        $response->setParameters($parameters);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame($parameters, $response->getParameters());
+    }
+
+    /**
+     * Responses beyond the configured byte limit become a concise HTTP 413 error.
+     */
+    public function test_response_beyond_size_limit_is_rejected(): void {
+        $response = new api_response();
+        $response->set_response_size_limit(6, 'Narrow the Moodle request.');
+
+        $response->setParameters(['a' => 1]);
+
+        $this->assertSame(413, $response->getStatusCode());
+        $this->assertSame([
+            'error' => 'response_too_large',
+            'error_description' => 'Narrow the Moodle request.',
+        ], $response->getParameters());
+        $this->assertSame('no-store', $response->getHttpHeader('Cache-Control'));
+    }
+}

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component    = 'local_learnwise';
-$plugin->release      = '1.4.6a';
-$plugin->version      = 2026081001;
+$plugin->release      = '1.4.7a';
+$plugin->version      = 2026081900;
 $plugin->requires     = 2020061500;
 $plugin->supported    = [39, 502];
 $plugin->maturity     = MATURITY_STABLE;


### PR DESCRIPTION
## Summary

- Remove implicit top-level pagination from the AI Ops Moodle web-service proxy. Responses are no longer sliced to 50 items and no pagination headers are emitted.
- Reject cleaned Moodle JSON responses larger than 10 MiB with HTTP 413 before the response body is sent.
- Keep legacy `_page` and `_per_page` query controls ignored, rather than forwarding them as invalid parameters to Moodle.
- Bump the plugin release to `1.4.7a`.

## Why

The proxy paginated every top-level list after Moodle had already produced the full result. Callers that did not know about the plugin-specific pagination received only the first 50 items, which caused incomplete enrolment data in course audits. Since pagination did not reduce Moodle-side work or memory, returning the complete result is both simpler and correct. The 10 MiB guard retains a transport-level safety limit for unusually large results and tells callers to narrow the native Moodle request.


Linear: [INNO-828](https://linear.app/learnwise/issue/INNO-828/course-audit-reports-no-students-when-moodle-enrolments-are-truncated)
