### PR TITLE
fix: use aiden-sbx.learnwise.dev for sandbox remote host

### DIFF
--- a/classes/util.php
+++ b/classes/util.php
@@ -309,7 +309,11 @@ class util {
      * @return string
      */
     public static function get_remotehosturl($env = null) {
-        return str_replace('chat.', 'aiden.', self::get_ltitoolurl($env));
+        return str_replace(
+            ['chat.', 'aiden.sandbox'],
+            ['aiden.', 'aiden-sbx'],
+            self::get_ltitoolurl($env)
+        );
     }
 
     /**

--- a/templates/assistantwidget.mustache
+++ b/templates/assistantwidget.mustache
@@ -26,7 +26,7 @@
       "userid": "2",
       "userfullname": "Admin User",
       "useremail": "admin@test.com",
-      "remotehost": "https:\/\/aiden.sandbox.learnwise.dev",
+      "remotehost": "https:\/\/aiden-sbx.learnwise.dev",
       "chathost": "https:\/\/chat.sandbox.learnwise.dev"
     }
 }}


### PR DESCRIPTION
The sandbox Aiden host moved from aiden.sandbox.learnwise.dev to aiden-sbx.learnwise.dev. Rewrite it in get_remotehosturl(), mirroring the existing lti-sbx rename in get_ltiprefixurl(). The chat host is unchanged.